### PR TITLE
Set channel status to INTERRUPTED when user hangs up on a none-bargei…

### DIFF
--- a/solutions/asterisk-unimrcp/app-unimrcp/app_mrcprecog.c
+++ b/solutions/asterisk-unimrcp/app-unimrcp/app_mrcprecog.c
@@ -1130,6 +1130,13 @@ static int app_recog_exec(struct ast_channel *chan, ast_app_data data)
 			if (bargein == 0) {
 				/* Barge-in is not allowed, wait for stream to end. */
 				if (ast_waitstream(chan, "") != 0) {
+					f = ast_read(chan);
+					if (!f) {
+						ast_log(LOG_DEBUG, "(%s) ast_waitstream failed on %s, channel read is a null frame. Hangup detected\n", name, ast_channel_name(chan));
+						return mrcprecog_exit(chan, &mrcprecog_session, SPEECH_CHANNEL_STATUS_INTERRUPTED);
+					}
+					ast_frfree(f);
+
 					ast_log(LOG_WARNING, "(%s) ast_waitstream failed on %s\n", name, ast_channel_name(chan));
 					return mrcprecog_exit(chan, &mrcprecog_session, SPEECH_CHANNEL_STATUS_ERROR);
 				}

--- a/solutions/asterisk-unimrcp/app-unimrcp/app_synthandrecog.c
+++ b/solutions/asterisk-unimrcp/app-unimrcp/app_synthandrecog.c
@@ -1519,6 +1519,13 @@ static int app_synthandrecog_exec(struct ast_channel *chan, ast_app_data data)
 			end_of_prompt = 0;
 			if(prompt_item->is_audio_file) {
 				if (ast_waitstream(chan, "") != 0) {
+					f = ast_read(chan);
+					if (!f) {
+						ast_log(LOG_DEBUG, "(%s) ast_waitstream failed on %s, channel read is a null frame. Hangup detected\n", recog_name, ast_channel_name(chan));
+						return synthandrecog_exit(chan, &sar_session, SPEECH_CHANNEL_STATUS_INTERRUPTED);
+					}
+					ast_frfree(f);
+
 					ast_log(LOG_WARNING, "(%s) ast_waitstream failed on %s\n", recog_name, ast_channel_name(chan));
 					return synthandrecog_exit(chan, &sar_session, SPEECH_CHANNEL_STATUS_ERROR);
 				}


### PR DESCRIPTION
…nable prompt. Thanks Tony.

git-svn-id: http://unimrcp.googlecode.com/svn@2202 f001bc3a-424a-0410-80a0-a715b8f413a8

**Note:** Incorporating Tony's changes to support INTERRUPTED channel status.

@sfgeorge I'm not sure if we need this or not yet in the Git repo; figured since we forked this from a SVN fork this would be the most straight-forward approach to incorporating the change based on what I've seen in Stockyard. I opted not to include any of the changes between r2168 and r2202, nor any of the changes since r2202. Would be more than happy to revisit if you'd like include those changes as well. 
